### PR TITLE
Remove the Forum reference in the api docs

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -58,12 +58,6 @@ For example, using the curl command line utility tool:
 curl https://www.trade-tariff.service.gov.uk/api/v2/sections
 ```
 
-## Keep informed
-
-There is a [discussion group](https://forum.trade-tariff.service.gov.uk/c/api) 
-for the GOV.UK Trade Tariff API. We will use this channel to communicate any changes, 
-updates, and status of the API.
-
 ## Authentication
 
 Usage of GOV.UK Trade Tariff API does not require authentication.


### PR DESCRIPTION
# Context
We are removing any reference to the forum in the API docs.

#Ticket
https://transformuk.atlassian.net/browse/HOTT-163