### PR TITLE
Adds missing header link for v1

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -11,7 +11,8 @@ service_link: /
 header_links:
   About: /
   Getting Started: /getting-started.html
-  API Docs: /reference.html
+  API Docs v1: /reference-v1.html
+  API Docs v2: /reference.html
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
 ga_tracking_id: UA-97208357-3


### PR DESCRIPTION
### Jira link

HOTT-182

### What?

I have added/removed/altered:

- [x] Added missing link to v1 documentation

### Why?

I am doing this because:

- This is part of our updates to improve the api documentation

### Have you? (optional)

- [ ] Reviewed the documentation with the relevant stakeholders
- [ ] Followed the documentation through yourself to check it is correct
